### PR TITLE
feat: Enhance uuid gen

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -62,10 +62,14 @@ runs:
         chmod 700 "$SSH_KEY_DIR"
         echo "SSH_KEY_DIR=$SSH_KEY_DIR" >> $GITHUB_ENV
 
+    - name: Set UUID
+      id: generate-uuid
+      uses: filipstefansson/uuid-action@v1
+
     - name: 'Add SSH Key to the Temporary Directory'
       shell: bash
       run: |
-        UUID=$(uuidgen)
+        UUID=${{ steps.generate-uuid.outputs.uuid }}
         SSH_KEY_PATH="$SSH_KEY_DIR/${UUID}_id_rsa"
         echo "${{ inputs.ssh_private_key }}" > "$SSH_KEY_PATH"
         chmod 600 "$SSH_KEY_PATH"


### PR DESCRIPTION
In fact, when encountering a Windows system, an error will occur because Windows generally does not have uuidgen.

```
Run ajaxer-org/git-repo-clone-action@v2.2
Run if [[ -z "../rnidbg" ]]; then
Run echo "DIRECTORY=../rnidbg"
DIRECTORY=../rnidbg
Run SSH_KEY_DIR="$HOME/.ssh/temp_keys"
Run UUID=$(uuidgen)
D:\a\_temp\d369a6c3-cf22-4948-8a77-66a259821534.sh: line 1: uuidgen: command not found
Error: Process completed with exit code 127.
```


So, this PR supports more general uuid gen to enhance repository cloning by importing `filipstefansson/uuid-action@v1`.